### PR TITLE
An implementation of PWM

### DIFF
--- a/RTK.GPIO/Hardware/README.md
+++ b/RTK.GPIO/Hardware/README.md
@@ -78,3 +78,10 @@ The micro USB and UART connectors are connected to the serial chip interface, wh
 * Supports both 5V and 3.3V operation
 
 The CH340G on the RTk.GPIO uses UART Mode at 3v3. The RTk.GPIO uses a baudrate of 230400.
+
+# Drivers
+
+Links for divers:
+
+## Windows: https://github.com/C0deGyver/CH340-Drivers-for-Windows
+## Mac: https://github.com/adrianmihalko/ch340g-ch34g-ch34x-mac-os-x-driver

--- a/RTK.GPIO/Software/RTk/GPIO.py
+++ b/RTK.GPIO/Software/RTk/GPIO.py
@@ -30,7 +30,7 @@ RPI_INFO = {'P1_REVISION': 3, 'RAM': 'Unknown', 'REVISION': '90092', 'TYPE': 'Un
 
 from RTk import protocol
 from RTk import adaptors
-
+from RTk.PWM import PWM_Mod as PWM
 
 #from os import sys, path
 #thisdir = path.dirname(path.abspath(__file__))

--- a/RTK.GPIO/Software/RTk/PWM.py
+++ b/RTK.GPIO/Software/RTk/PWM.py
@@ -1,0 +1,36 @@
+#RTK.GPIO implementation of PWM courtesy of C0deGyver
+from time import sleep
+try:
+        import GPIO as GPIO
+except:
+        import RTk.GPIO as GPIO
+
+class PWM_Mod:
+        """
+                fake PWM output using sleep
+                included a position calulator function
+                   this function should work with *most* PWM servos by default; but check your spec sheet
+        """
+
+        def __init__(self, initPWMPIN, initFREQUENCY):
+                self.PWMPIN = initPWMPIN
+                self.FREQUENCY = initFREQUENCY
+                self.MILS = 0.01
+
+        def start(self, startDutyCycle):
+                startDutyCycle = round(startDutyCycle)
+                for x in range(startDutyCycle):
+                        GPIO.output(self.PWMPIN, GPIO.HIGH)
+                        sleep(self.milS)
+                        GPIO.output(self.PWMPIN, GPIO.LOW)
+                        sleep(self.milS)
+
+        def servoCalc(self, location, FREQUENCY = 50, minPW = 1, maxPW = 2):
+                period = (1 / frequency) * 1000
+                if (location <= 180):
+                        pulseWidth = (((maxPW - minPW) / 180) * location) + minPW
+                else:
+                        pulseWidth = (((maxPW - minPW) / 360) * location) + minPW
+                dutyCycle = pulseWidth / period
+
+                return dutyCycle

--- a/RTK.GPIO/Software/examples/testLED.py
+++ b/RTK.GPIO/Software/examples/testLED.py
@@ -1,0 +1,16 @@
+#!/bin/env python
+import RTk.GPIO as GPIO
+from time import sleep
+
+LED = 11
+
+GPIO.setmode(GPIO.BOARD)
+GPIO.setup(LED, GPIO.OUT)
+
+for x in range(6):
+	GPIO.output(LED ,GPIO.HIGH)
+	sleep(2)
+	GPIO.output(LED ,GPIO.LOW)
+	sleep(2)
+
+GPIO.cleanup()

--- a/RTK.GPIO/Software/examples/testPWM.py
+++ b/RTK.GPIO/Software/examples/testPWM.py
@@ -1,24 +1,14 @@
-# testLED.py - 06/06/2014 D.J.Whale
-# Modified by Ryan Walmsley
-# Test flashing an LED
-
-from time import sleep
-t = 0.01
-
-
-# RTk.GPIO
+#!/bin/env python
 import RTk.GPIO as GPIO
 
-P = 22
+PWMPIN = 11
+FREQUENCY = 50
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(P, GPIO.OUT)
+GPIO.setmode(GPIO.BOARD)
+GPIO.setup(PWMPIN, GPIO.OUT)
+pwm = GPIO.PWM(PWMPIN, FREQUENCY)
 
+for i in range(181):
+	pwm.start(servoCalc(i))
 
-while True:
-	GPIO.output(P, True)
-	sleep(t)
-	GPIO.output(P, False)
-	sleep(t)
-
-# END
+GPIO.cleanup()


### PR DESCRIPTION
I have added a "fake" implementation of PWM using sleep.
In the PWM class there is a simple DutyCycle calculator to make controlling PWM servos easier.

I changed the Software/examples/testPWM.py file to use the new PWM fuinctionality.
I created an example LED test file as there was no output test file currently.

I added a drivers section in Hardware/README.md as I did not realize installing a driver was nessary (in Windows 7 at least)